### PR TITLE
Merge upstream fork (0.9.1)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,8 @@
+Version 0.9.1 (2021-10-26)
+--------------------------
+Update python versions in run-tests script (#256)
+Fix pycontracts incompatibility with pyparsing v3 (#255)
+
 Version 0.9.0 (2021-04-23)
 --------------------------
 Fix items default value issue in track_ecommerce_transaction (#252)

--- a/README.rst
+++ b/README.rst
@@ -67,7 +67,7 @@ Assuming pyenv_ is installed
 
    host$ git clone git@github.com:snowplow/snowplow-python-tracker.git
    host$ cd snowplow-python-tracker
-   host$ pyenv install 2.7.18 && pyenv install 3.5.10 && pyenv install 3.6.13 && pyenv install 3.7.10 && pyenv install 3.8.9 && pyenv install 3.9.2
+   host$ pyenv install 2.7.18 && pyenv install 3.5.10 && pyenv install 3.6.14 && pyenv install 3.7.11 && pyenv install 3.8.11 && pyenv install 3.9.6
    host$ ./run-tests.sh deploy
    host$ ./run-tests.sh test
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -15,7 +15,7 @@ eval "$(pyenv init -)"
 eval "$(pyenv virtualenv-init -)"
 
 function deploy {
-  # pyenv install 2.7.15
+  # pyenv install 2.7.18
   if [ ! -e ~/.pyenv/versions/tracker27 ]; then
     pyenv virtualenv 2.7.18 tracker27
     pyenv activate tracker27
@@ -49,9 +49,9 @@ function deploy {
     source deactivate
   fi
 
-  # pyenv install 3.6.12
+  # pyenv install 3.6.14
   if [ ! -e ~/.pyenv/versions/tracker36 ]; then
-    pyenv virtualenv 3.6.12 tracker36
+    pyenv virtualenv 3.6.14 tracker36
     pyenv activate tracker36
     pip install .
     pip install -r requirements-test.txt
@@ -59,16 +59,16 @@ function deploy {
   fi
 
   if [ ! -e ~/.pyenv/versions/tracker36redis ]; then
-    pyenv virtualenv 3.6.12 tracker36redis
+    pyenv virtualenv 3.6.14 tracker36redis
     pyenv activate tracker36redis
     pip install .[redis]
     pip install -r requirements-test.txt
     source deactivate
   fi
 
-  # pyenv install 3.7.9
+  # pyenv install 3.7.11
   if [ ! -e ~/.pyenv/versions/tracker37 ]; then
-    pyenv virtualenv 3.7.9 tracker37
+    pyenv virtualenv 3.7.11 tracker37
     pyenv activate tracker37
     pip install .
     pip install -r requirements-test.txt
@@ -76,16 +76,16 @@ function deploy {
   fi
 
   if [ ! -e ~/.pyenv/versions/tracker37redis ]; then
-    pyenv virtualenv 3.7.9 tracker37redis
+    pyenv virtualenv 3.7.11 tracker37redis
     pyenv activate tracker37redis
     pip install .[redis]
     pip install -r requirements-test.txt
     source deactivate
   fi
 
-  # pyenv install 3.8.6
+  # pyenv install 3.8.11
   if [ ! -e ~/.pyenv/versions/tracker38 ]; then
-    pyenv virtualenv 3.8.6 tracker38
+    pyenv virtualenv 3.8.11 tracker38
     pyenv activate tracker38
     pip install .
     pip install -r requirements-test.txt
@@ -93,16 +93,16 @@ function deploy {
   fi
 
   if [ ! -e ~/.pyenv/versions/tracker38redis ]; then
-    pyenv virtualenv 3.8.6 tracker38redis
+    pyenv virtualenv 3.8.11 tracker38redis
     pyenv activate tracker38redis
     pip install .[redis]
     pip install -r requirements-test.txt
     source deactivate
   fi
 
-  # pyenv install 3.9.0
+  # pyenv install 3.9.6
   if [ ! -e ~/.pyenv/versions/tracker39 ]; then
-    pyenv virtualenv 3.9.0 tracker39
+    pyenv virtualenv 3.9.6 tracker39
     pyenv activate tracker39
     pip install .
     pip install -r requirements-test.txt
@@ -110,7 +110,7 @@ function deploy {
   fi
 
   if [ ! -e ~/.pyenv/versions/tracker39redis ]; then
-    pyenv virtualenv 3.9.0 tracker39redis
+    pyenv virtualenv 3.9.6 tracker39redis
     pyenv activate tracker39redis
     pip install .[redis]
     pip install -r requirements-test.txt

--- a/setup.py
+++ b/setup.py
@@ -73,8 +73,8 @@ setup(
 
     install_requires=[
         "requests>=2.25.1,<3.0",
-        "pycontracts>=1.8.12,<2.0",
-        "decorator>=4.4,<5.0;python_version<'3.6'",
+        "pycontracts>=1.8.12;python_version<'3.0'",
+        "pycontracts3>=3.0.2;python_version>='3.0'",
         "six>=1.9.0,<2.0"
     ],
 

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ authors_email_str = ', '.join(authors_email_list)
 
 setup(
     name='snowplow-tracker',
-    version='0.9.0',
+    version='0.9.1',
     author=authors_str,
     author_email=authors_email_str,
     packages=['snowplow_tracker', 'snowplow_tracker.test', 'snowplow_tracker.redis', 'snowplow_tracker.celery'],

--- a/snowplow_tracker/_version.py
+++ b/snowplow_tracker/_version.py
@@ -20,6 +20,6 @@
 """
 
 
-__version_info__ = (0, 9, 0)
+__version_info__ = (0, 9, 1)
 __version__ = ".".join(str(x) for x in __version_info__)
 __build_version__ = __version__ + ''


### PR DESCRIPTION
Merging changes from the upstream repository. 

Our previous fork point pinned dependencies (pycontracts) in a different way to the upstream repository. The upstream repository has resolved this in v0.9.1.

This will be used as the base to merge our own additional changes for supporting session_id and index (which the upstream repository does not currently support).